### PR TITLE
genie_wrapper: added genie wrapper systemd_start.sh; removed managed_user var

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -132,7 +132,6 @@ function _play {
   # shellcheck disable=SC2027
   local play_args=(
     --ask-become-pass
-    --extra-vars "managed_user=$(whoami)"
     --extra-vars "'{\"init_roles\": [$(IFS=, echo -n "${ROLES[*]}")]}'"
   )
 
@@ -222,7 +221,7 @@ function main {
     fi
   done
 
-  >&2 echo "All set! If this script was run for a WSL role, remember to run genie --shell to enter the kernel namespace mounted for systemd."
+  >&2 echo 'All set! If this script was run for a WSL role, remember to run "${HOME}/bin/systemd_start.sh" to enter the kernel namespace mounted for systemd.'
 }
 
 main

--- a/roles/cjvdev_wsl/tasks/main.yml
+++ b/roles/cjvdev_wsl/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- name: Checking HOME (Ubuntu)
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.env', 'HOME') | length > 0
+    fail_msg: 'HOME environment variable was not set. This is needed so the play knows where to place the systemd_start.sh script.'
+
+- name: Create systemd_start.sh script
+  ansible.builtin.template:
+    dest: "{{ lookup('ansible.builtin.env', 'HOME') }}/bin/systemd_start.sh" 
+    mode: 0755
+    src: templates/systemd_start.sh.j2
+  become: True
+  tags:
+  - cjvdev_wsl
+
 - name: Install cjvdev
   ansible.builtin.include_tasks:
     file: roles/cjvdev/tasks/install_cjvdev.yml

--- a/roles/cjvdev_wsl/templates/systemd_start.sh.j2
+++ b/roles/cjvdev_wsl/templates/systemd_start.sh.j2
@@ -3,7 +3,9 @@
 set -e
 
 function main {
-  genie --initialize &>/dev/null &
+  if ! pgrep -xo systemd; then
+    genie --initialize &>/dev/null &
+  fi
 
   while ! pgrep -xo systemd; do
     >&2 echo "waiting for systemd"

--- a/roles/cjvdev_wsl/templates/systemd_start.sh.j2
+++ b/roles/cjvdev_wsl/templates/systemd_start.sh.j2
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+function main {
+  genie --initialize &>/dev/null &
+
+  while ! pgrep -xo systemd; do
+    >&2 echo "waiting for systemd"
+    sleep 1
+  done
+
+  genie --command bash -c "systemctl --failed | grep -E '^●' | awk '{print \$2}' | xargs -I {} sudo systemctl start {}"
+
+  genie --shell
+}
+
+main

--- a/roles/docker/tasks/install_docker.yml
+++ b/roles/docker/tasks/install_docker.yml
@@ -47,16 +47,17 @@
     state: present
   become: True
 
-- name: Checking managed_user (Ubuntu)
-  fail:
-    msg: 'managed_user variable was not set. You can set this by running the playbook with the --extra-vars option.'
-  when: managed_user is not defined
+- name: Checking USER (Ubuntu)
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.env', 'USER') | length > 0
+    fail_msg: 'USER environment variable was not set. This is needed so the play knows who to add to the docker group.'
 
-- name: Adding managed_user to Docker Group (Ubuntu)
+- name: Adding USER to Docker Group (Ubuntu)
   user:
     groups: docker
     append: True
-    name: "{{ managed_user }}"
+    name: "{{ lookup('ansible.builtin.env', 'USER') }}"
   become: True
 
 - name: Restart Docker Daemon


### PR DESCRIPTION
* added `genie` wrapper `systemd_start.sh`
* removed `managed_user`
* using [assert](https://docs.ansible.com/ansible/2.9/modules/assert_module.html) module to assert presence of environment variables
