### PR TITLE
chore(cleanup): no longer need genie for systemd as of wsl 0.67.6

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,7 @@
 ---
 exclude_paths:
-- requirements.yml
+  - requirements.yml
+  - .github
 skip_list:
-# we do not generate roles with ansible-galaxy
-- meta-no-info
+  # we do not generate roles with ansible-galaxy
+  - meta-no-info

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,10 @@
 ---
+# ignoring nvidia and tplink for now
 exclude_paths:
   - requirements.yml
   - .github
+  - roles/nvidia
+  - roles/tplink
 skip_list:
   # we do not generate roles with ansible-galaxy
   - meta-no-info

--- a/roles/bitwarden/tasks/main.yml
+++ b/roles/bitwarden/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Download and install bw
   ansible.builtin.unarchive:
     dest: /usr/local/bin
-    mode: 0755
+    mode: "0755"
     remote_src: true
     src: "https://vault.bitwarden.com/download/?app=cli&platform=linux"
   become: true

--- a/roles/cjvdev/tasks/install_cjvdev.yml
+++ b/roles/cjvdev/tasks/install_cjvdev.yml
@@ -2,7 +2,7 @@
 - name: Create profile script
   ansible.builtin.template:
     dest: /etc/profile.d/00-cjvdev.sh
-    mode: 0755
+    mode: "0755"
     src: roles/cjvdev/templates/00-cjvdev.sh.j2
   become: true
   tags:
@@ -21,7 +21,7 @@
   ansible.builtin.get_url:
     checksum: "{{ clconf_checksum }}"
     dest: /usr/local/bin/clconf
-    mode: 0755
+    mode: "0755"
     url: "https://github.com/pastdev/clconf/releases/download/v{{ clconf_version }}/clconf-linux"
   become: true
   tags:

--- a/roles/cjvdev/tasks/install_gh.yml
+++ b/roles/cjvdev/tasks/install_gh.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create gh dir
   ansible.builtin.file:
-    mode: 0755
+    mode: "0755"
     path: "{{ gh_dir }}"
     state: directory
   become: true
@@ -9,14 +9,14 @@
 - name: Install gh
   ansible.builtin.unarchive:
     dest: "{{ gh_dir }}"
-    mode: 0755
+    mode: "0755"
     src: "https://github.com/cli/cli/releases/download/v{{ gh_version }}/gh_{{ gh_version }}_linux_amd64.tar.gz"
     remote_src: true
   become: true
 
 - name: Create symlinks
   ansible.builtin.file:
-    mode: 0755
+    mode: "0755"
     path: "/usr/local/bin/{{ gh_bin_path | basename }}"
     src: "{{ gh_bin_path }}"
     state: link

--- a/roles/nordvpn/tasks/install_openvpn_configs.yml
+++ b/roles/nordvpn/tasks/install_openvpn_configs.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create config dir
   ansible.builtin.file:
-    mode: 0755
+    mode: "0755"
     path: "{{ ovpn_config_dir }}"
     state: directory
   become: true
@@ -9,14 +9,14 @@
 - name: Install OpenVPN configs
   ansible.builtin.unarchive:
     dest: "{{ ovpn_config_dir }}"
-    mode: 0755
+    mode: "0755"
     remote_src: true
     src: 'https://downloads.nordcdn.com/configs/archives/servers/ovpn.zip'
   become: true
 
 - name: Create symlink
   ansible.builtin.file:
-    mode: 0755
+    mode: "0755"
     path: "/etc/openvpn/{{ ovpn_transport_protocol_dir | basename }}"
     src: "{{ ovpn_transport_protocol_dir }}"
     state: link

--- a/roles/nordvpn/tasks/main.yml
+++ b/roles/nordvpn/tasks/main.yml
@@ -14,6 +14,6 @@
 - name: Create nordvpn.sh script
   ansible.builtin.template:
     dest: /usr/local/bin/nordvpn.sh
-    mode: 0755
+    mode: "0755"
     src: templates/nordvpn.sh.j2
   become: true

--- a/roles/tplink/handlers/install_tplink_archer.yml
+++ b/roles/tplink/handlers/install_tplink_archer.yml
@@ -2,7 +2,7 @@
 - name: Download rtl88x2bu source
   ansible.builtin.unarchive:
     dest: "/usr/src/rtl88x2bu-{{ package_version }}"
-    mode: 0755
+    mode: "0755"
     remote_src: true
     src: "https://github.com/cilynx/rtl88x2bu/archive/refs/heads/{{ package_version }}_35809.20191129_COEX20191120-7777.zip"
   listen: install_driver


### PR DESCRIPTION
see [this article](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/)
